### PR TITLE
Fix local timezone dependency in tests.

### DIFF
--- a/MTDatesTests/MTDatesTests.m
+++ b/MTDatesTests/MTDatesTests.m
@@ -20,6 +20,8 @@
 	_GMTFormatter.dateFormat = @"MM/dd/yyyy hh:mma";
     _GMTFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     
+    [NSTimeZone setDefaultTimeZone:[NSTimeZone timeZoneWithName:@"America/Denver"]];
+
     [super setUp];
 }
 


### PR DESCRIPTION
Time zone tests fail if local time zone is anything but Denver, Colorado
USA. Set local timezone in -setup in order to normalize test
environment.

---

I was trying to contribute to the project, but noticed the tests were failing. It seemed like `[NSDate setTimeZone:[NSTimeZone defaultTimeZone]];` was causing the failures, and sure enough, changing my MacBook's time zone to Denver fixed the issue. This commit is the minimal amount of code which seems to fix the problem.

Have you considered using OCMockito or Kiwi? That way I could so something like:

```
[NSTimeZone stub:@selector(defaultTimeZone) andReturn:[NSTimeZone timeZoneWithName:@"America/Denver"]];
```

The above would also make it easier to write tests to assert desired behavior in various timezones.

Anyway, awesome project, as usual. Kudos to everyone at Mysterious Trousers, LLC.
