### PR TITLE
Add further convenience class methods for constructing NSDate objects

### DIFF
--- a/MTDates/NSDate+MTDates.h
+++ b/MTDates/NSDate+MTDates.h
@@ -57,7 +57,12 @@ typedef enum {
 - (NSDate *)mt_dateByAddingYears:(NSInteger)years months:(NSInteger)months weeks:(NSInteger)weeks days:(NSInteger)days hours:(NSInteger)hours minutes:(NSInteger)minutes seconds:(NSInteger)seconds;
 + (NSDate *)mt_dateFromComponents:(NSDateComponents *)components;
 
-
++ (NSDate*)mt_startOfToday;
++ (NSDate*)mt_startOfYesterday;
++ (NSDate*)mt_startOfTomorrow;
++ (NSDate*)mt_endOfToday;
++ (NSDate*)mt_endOfYesterday;
++ (NSDate*)mt_endOfTomorrow;
 
 
 #pragma mark - SYMBOLS
@@ -297,6 +302,12 @@ typedef enum {
 + (NSDate *)dateFromYear:(NSUInteger)year week:(NSUInteger)week weekday:(NSUInteger)weekday hour:(NSUInteger)hour minute:(NSUInteger)minute second:(NSUInteger)second;
 - (NSDate *)dateByAddingYears:(NSInteger)years months:(NSInteger)months weeks:(NSInteger)weeks days:(NSInteger)days hours:(NSInteger)hours minutes:(NSInteger)minutes seconds:(NSInteger)seconds;
 + (NSDate *)dateFromComponents:(NSDateComponents *)components;
++ (NSDate*)startOfToday;
++ (NSDate*)startOfYesterday;
++ (NSDate*)startOfTomorrow;
++ (NSDate*)endOfToday;
++ (NSDate*)endOfYesterday;
++ (NSDate*)endOfTomorrow;
 
 + (NSArray *)shortWeekdaySymbols;
 + (NSArray *)weekdaySymbols;

--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -239,8 +239,47 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 	}
 }
 
++ (NSDate*)mt_startOfToday
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate date] mt_startOfCurrentDay];
+	}
+}
 
++ (NSDate*)mt_startOfYesterday
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate date] mt_startOfPreviousDay];
+	}
+}
 
++ (NSDate*)mt_startOfTomorrow
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate date] mt_startOfNextDay];
+	}
+}
+
++ (NSDate*)mt_endOfToday
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate date] mt_endOfCurrentDay];
+	}
+}
+
++ (NSDate*)mt_endOfYesterday
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate date] mt_endOfPreviousDay];
+	}
+}
+
++ (NSDate*)mt_endOfTomorrow
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate date] mt_endOfNextDay];
+	}
+}
 
 
 #pragma mark - SYMBOLS
@@ -1583,6 +1622,37 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 {
     return [self mt_dateFromComponents:components];
 }
+
++ (NSDate*)startOfToday
+{
+    return [self mt_startOfToday];
+}
+
++ (NSDate*)startOfYesterday
+{
+    return [self mt_startOfYesterday];
+}
+
++ (NSDate*)startOfTomorrow
+{
+    return [self mt_startOfTomorrow];
+}
+
++ (NSDate*)endOfToday
+{
+    return [self mt_endOfToday];
+}
+
++ (NSDate*)endOfYesterday
+{
+    return [self mt_endOfYesterday];
+}
+
++ (NSDate*)endOfTomorrow
+{
+    return [self mt_endOfTomorrow];
+}
+
 
 #pragma mark - SYMBOLS (NO PREFIX)
 

--- a/MTDatesTests/MTDatesTests.m
+++ b/MTDatesTests/MTDatesTests.m
@@ -123,7 +123,44 @@
     STAssertTrue([[date3 mt_dateByAddingYears:0 months:0 weeks:2 days:0 hours:1 minutes:24 seconds:0] isEqualToDate:date], nil);
 }
 
+- (void)test_startOfToday
+{
+    NSDate *date = [NSDate date];
+    NSDateComponents *comps = [date mt_components];
+    STAssertTrue([[NSDate mt_startOfToday] isEqualToDate:[NSDate mt_dateFromYear:[comps year] month:[comps month] day:[comps day]]], nil);
+}
 
+- (void)test_startOfYesterday
+{
+    NSDate *date = [[NSDate date] dateByAddingTimeInterval:-86400];
+    NSDateComponents *comps = [date mt_components];
+    STAssertTrue([[NSDate mt_startOfYesterday] isEqualToDate:[NSDate mt_dateFromYear:[comps year] month:[comps month] day:[comps day]]], nil);
+}
+
+- (void)test_startOfTomorrow
+{
+    NSDate *date = [[NSDate date] dateByAddingTimeInterval:86400];
+    NSDateComponents *comps = [date mt_components];
+    STAssertTrue([[NSDate mt_startOfTomorrow] isEqualToDate:[NSDate mt_dateFromYear:[comps year] month:[comps month] day:[comps day]]], nil);
+}
+
+- (void)test_endOfToday
+{
+    NSDate *date = [[NSDate mt_startOfTomorrow] dateByAddingTimeInterval:-1];
+    STAssertTrue([[NSDate mt_endOfToday] isEqualToDate:date], nil);
+}
+
+- (void)test_endOfTomorrow
+{
+    NSDate *date = [[NSDate mt_startOfTomorrow] dateByAddingTimeInterval:86400-1];
+    STAssertTrue([[NSDate mt_endOfTomorrow] isEqualToDate:date], nil);
+}
+
+- (void)test_endOfYesterday
+{
+    NSDate *date = [[NSDate mt_startOfToday] dateByAddingTimeInterval:-1];
+    STAssertTrue([[NSDate mt_endOfYesterday] isEqualToDate:date], nil);
+}
 
 
 #pragma mark - SYMBOLS


### PR DESCRIPTION
These methods are based on 'start' and 'end' of 'yesterday', 'today' and 'tomorrow'.

I've tried to mimic your existing styles and have included tests based on a different route.
