### PR TITLE
fixes #20 to successfully run tests on simulator with non-default locale

### DIFF
--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -1456,7 +1456,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
     }
 
     if (!__locale) {
-        __locale = [NSLocale currentLocale];
+        __locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
     }
 
     if (!__timeZone) {


### PR DESCRIPTION
Simply needed an explicit declaration of the locale assumed in the tests.
