### PR TITLE
Added mt_dayOfYear method, along with tests

### DIFF
--- a/MTDates/NSDate+MTDates.h
+++ b/MTDates/NSDate+MTDates.h
@@ -81,6 +81,7 @@ typedef enum {
 
 - (NSUInteger)mt_year;
 - (NSUInteger)mt_weekOfYear;
+- (NSUInteger)mt_dayOfYear;
 - (NSUInteger)mt_weekdayOfWeek;
 - (NSUInteger)mt_weekOfMonth;
 - (NSUInteger)mt_monthOfYear;
@@ -318,6 +319,7 @@ typedef enum {
 
 - (NSUInteger)year;
 - (NSUInteger)weekOfYear;
+- (NSUInteger)dayOfYear;
 - (NSUInteger)weekdayOfWeek;
 - (NSUInteger)weekOfMonth;
 - (NSUInteger)monthOfYear;

--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -347,6 +347,14 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 	}
 }
 
+- (NSUInteger)mt_dayOfYear
+{
+    @synchronized([NSDate mt_lockObject]){
+        return [[NSDate mt_calendar] ordinalityOfUnit:NSDayCalendarUnit
+                                               inUnit:NSYearCalendarUnit forDate:self];
+	}
+}
+
 - (NSUInteger)mt_weekOfMonth
 {
 	@synchronized([NSDate mt_lockObject]){
@@ -1696,6 +1704,11 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 - (NSUInteger)weekOfYear
 {
     return [self mt_weekOfYear];
+}
+
+- (NSUInteger)dayOfYear
+{
+    return [self mt_dayOfYear];
 }
 
 - (NSUInteger)weekdayOfWeek

--- a/MTDatesTests/MTDatesTests.m
+++ b/MTDatesTests/MTDatesTests.m
@@ -213,6 +213,15 @@
     STAssertTrue([date mt_weekOfYear] == 28, nil);
 }
 
+- (void)test_dayOfYear
+{
+    NSDate *date = [_formatter dateFromString:@"07/11/1986 11:29am"];
+    STAssertTrue([date mt_dayOfYear] == 192, nil);
+    // test for leap year as well
+    date = [_formatter dateFromString:@"07/11/1988 11:29am"];
+    STAssertTrue([date mt_dayOfYear] == 193, nil);
+}
+
 - (void)test_weekOfMonth
 {
     NSDate *date = [_formatter dateFromString:@"07/11/1986 11:29am"];


### PR DESCRIPTION
This pull request adds a method to return the day of the year.

The approach was taken from http://stackoverflow.com/questions/2080927/how-do-you-calculate-the-day-of-the-year-for-a-specific-date-in-objective-c
