### PR TITLE
Use firstWeekday and from current calendar if not set

### DIFF
--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -36,8 +36,8 @@ static NSDateFormatter              *__formatter            = nil;
 static NSString                     *__calendarType         = nil;
 static NSLocale                     *__locale               = nil;
 static NSTimeZone                   *__timeZone             = nil;
-static NSUInteger                   __firstWeekday          = 1;
-static MTDateWeekNumberingSystem    __weekNumberingSystem   = 1;
+static NSUInteger                   __firstWeekday          = 0;
+static MTDateWeekNumberingSystem    __weekNumberingSystem   = 0;
 
 static NSDateFormatterStyle         __dateStyle             = NSDateFormatterShortStyle;
 static NSDateFormatterStyle         __timeStyle             = NSDateFormatterShortStyle;
@@ -1459,8 +1459,18 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 
 + (void)mt_prepareDefaults
 {
+    NSCalendar *currentCalendar = (NSCalendar *)[NSCalendar currentCalendar];
+
     if (!__calendarType) {
-        __calendarType = [(NSCalendar *)[NSCalendar currentCalendar] calendarIdentifier];
+        __calendarType = [currentCalendar calendarIdentifier];
+    }
+
+    if (__weekNumberingSystem == 0) {
+        __weekNumberingSystem = [currentCalendar minimumDaysInFirstWeek];
+    }
+
+    if (__firstWeekday == 0) {
+        __firstWeekday = [currentCalendar firstWeekday];
     }
 
     if (!__locale) {
@@ -1517,7 +1527,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
         __calendar      = nil;
         __components    = nil;
         __formatter     = nil;
-	}
+  }
 }
 
 + (id)mt_lockObject


### PR DESCRIPTION
In application I'm working on I need to work with the first day of week for a given date. I'm getting that value with `mt_startOfCurrentWeek`. But recently I've noticed the problem when in user's calendar week starts from Monday (i.e/ United Kingdom). `mt_startOfCurrentWeek` was returning Sunday as the beginning of week like for USA.

As a workaround I can set up first weekday before using MTDates:

``` objective-c
[NSDate mt_setFirstDayOfWeek:[[NSCalendar currentCalendar] firstWeekday]]
```

But I don't think it's a correct way. I think it would be better if MTDates will just work out of the box with current user's preferences...

I don't know how better to prove this with unit tests... Here is the list of steps for manual testing:
1. switch region format to "United Kingdom" on a device or a simulator (Settings => General => International => Region format)
2. log `[[NSDate date] mt_startOfCurrentWeek]` somewhere in the app with MTDates included.

Expected: the date should be Monday.
Result: always Sunday.
