### PR TITLE
Uninstall xctool on Travis before installing it again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
 before_install:
   - brew update
-  - brew install xctool
+  - brew uninstall xctool && brew install xctool
 script: xctool test


### PR DESCRIPTION
Attempt to fix broken build because of "Error: xctool-0.1.7 already installed".

https://travis-ci.org/mysterioustrousers/MTDates/builds/10717206
