### PR TITLE
replacing deprecated week with weekOfYear

### DIFF
--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -210,7 +210,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 	[[NSDate sharedRecursiveLock] lock];
     NSDateComponents *comps = [NSDate mt_components];
     [comps setYear:year];
-    [comps setWeek:week];
+    [comps setWeekOfYear:week];
     [comps setWeekday:weekday];
     [comps setHour:hour];
     [comps setMinute:minute];
@@ -226,7 +226,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
     NSDateComponents *comps = [NSDate mt_components];
     if (years)      [comps setYear:years];
     if (months)     [comps setMonth:months];
-    if (weeks)      [comps setWeek:weeks];
+    if (weeks)      [comps setWeekOfYear:weeks];
     if (days)       [comps setDay:days];
     if (hours)      [comps setHour:hours];
     if (minutes)    [comps setMinute:minutes];
@@ -775,7 +775,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 {
 	[[NSDate sharedRecursiveLock] lock];
     NSDateComponents *components = [[NSDate mt_calendar] components:NSWeekCalendarUnit fromDate:date toDate:self options:0];
-    NSInteger weeks = [components week];
+    NSInteger weeks = [components weekOfYear];
 	[[NSDate sharedRecursiveLock] unlock];
     return weeks;
 }
@@ -784,7 +784,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 {
 	[[NSDate sharedRecursiveLock] lock];
     NSDateComponents *components = [[NSDate mt_calendar] components:NSWeekCalendarUnit fromDate:self toDate:date options:0];
-    NSInteger weeks = [components week];
+    NSInteger weeks = [components weekOfYear];
 	[[NSDate sharedRecursiveLock] unlock];
     return weeks;
 }
@@ -1660,7 +1660,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
     [__components setHour:NSUndefinedDateComponent];
     [__components setMinute:NSUndefinedDateComponent];
     [__components setSecond:NSUndefinedDateComponent];
-    [__components setWeek:NSUndefinedDateComponent];
+    [__components setWeekOfYear:NSUndefinedDateComponent];
     [__components setWeekday:NSUndefinedDateComponent];
     [__components setWeekdayOrdinal:NSUndefinedDateComponent];
     [__components setQuarter:NSUndefinedDateComponent];

--- a/MTDates/NSDateComponents+MTDates.m
+++ b/MTDates/NSDateComponents+MTDates.m
@@ -72,14 +72,13 @@
   BOOL hour   = self.hour               == components.hour;
   BOOL min    = self.minute             == components.minute;
   BOOL sec    = self.second             == components.second;
-  BOOL week   = self.week               == components.week;
   BOOL wkday  = self.weekday            == components.weekday;
   BOOL wkOrd  = self.weekdayOrdinal     == components.weekdayOrdinal;
   BOOL quart  = self.quarter            == components.quarter;
   BOOL wkofM  = self.weekOfMonth        == components.weekOfMonth;
   BOOL wkofY  = self.weekOfYear         == components.weekOfYear;
   BOOL YfWoY  = self.yearForWeekOfYear  == components.yearForWeekOfYear;
-  return era && year && month && month && day && hour && min && sec && week && wkday && wkOrd && quart && wkofM && wkofY && YfWoY;
+  return era && year && month && month && day && hour && min && sec && wkday && wkOrd && quart && wkofM && wkofY && YfWoY;
 }
 
 #if MTDATES_NO_PREFIX


### PR DESCRIPTION
This method was deprecated in iOS 7 and replaced with weekOfMonth and weekOfYear.

https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/Foundation/Classes/NSDateComponents_Class/index.html#//apple_ref/occ/instm/NSDateComponents/week
