### PR TITLE
Replace deprecated undefined date component

### DIFF
--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -1653,17 +1653,17 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
         if (__timeZone) __components.timeZone = __timeZone;
     }
 
-    [__components setEra:NSUndefinedDateComponent];
-    [__components setYear:NSUndefinedDateComponent];
-    [__components setMonth:NSUndefinedDateComponent];
-    [__components setDay:NSUndefinedDateComponent];
-    [__components setHour:NSUndefinedDateComponent];
-    [__components setMinute:NSUndefinedDateComponent];
-    [__components setSecond:NSUndefinedDateComponent];
-    [__components setWeekOfYear:NSUndefinedDateComponent];
-    [__components setWeekday:NSUndefinedDateComponent];
-    [__components setWeekdayOrdinal:NSUndefinedDateComponent];
-    [__components setQuarter:NSUndefinedDateComponent];
+    [__components setEra:NSDateComponentUndefined];
+    [__components setYear:NSDateComponentUndefined];
+    [__components setMonth:NSDateComponentUndefined];
+    [__components setDay:NSDateComponentUndefined];
+    [__components setHour:NSDateComponentUndefined];
+    [__components setMinute:NSDateComponentUndefined];
+    [__components setSecond:NSDateComponentUndefined];
+    [__components setWeekOfYear:NSDateComponentUndefined];
+    [__components setWeekday:NSDateComponentUndefined];
+    [__components setWeekdayOrdinal:NSDateComponentUndefined];
+    [__components setQuarter:NSDateComponentUndefined];
 
     return __components;
 }

--- a/MTDates/NSDateComponents+MTDates.m
+++ b/MTDates/NSDateComponents+MTDates.m
@@ -34,9 +34,9 @@
   }
 
   // if the day was set but the month wasn't, interpret the two digits as the month
-  if ([comps month] == NSUndefinedDateComponent && [comps day] != NSUndefinedDateComponent) {
+  if ([comps month] == NSDateComponentUndefined && [comps day] != NSDateComponentUndefined) {
     [comps setMonth:MIN([comps day], 12)];
-    [comps setDay:NSUndefinedDateComponent];
+    [comps setDay:NSDateComponentUndefined];
   }
 
   return comps;
@@ -46,18 +46,18 @@
 {
   NSMutableArray *partsArray = [NSMutableArray array];
   NSDateComponents *required = [self copy];
-  required.year = self.year   == NSUndefinedDateComponent ? 1970  : self.year;
-  required.month  = self.month  == NSUndefinedDateComponent ? 1   : self.month;
-  required.day  = self.day    == NSUndefinedDateComponent ? 1   : self.day;
+  required.year = self.year   == NSDateComponentUndefined ? 1970  : self.year;
+  required.month  = self.month  == NSDateComponentUndefined ? 1   : self.month;
+  required.day  = self.day    == NSDateComponentUndefined ? 1   : self.day;
   NSDate *date = [NSDate mt_dateFromComponents:required];
 
-  if ([self day] != NSUndefinedDateComponent) {
+  if ([self day] != NSDateComponentUndefined) {
     [partsArray addObject:[date mt_stringFromDateWithFormat:@"dd" localized:NO]];
   }
-  if ([self month] != NSUndefinedDateComponent) {
+  if ([self month] != NSDateComponentUndefined) {
     [partsArray addObject:[date mt_stringFromDateWithFormat:@"MMMM" localized:NO]];
   }
-  if ([self year] != NSUndefinedDateComponent) {
+  if ([self year] != NSDateComponentUndefined) {
     [partsArray addObject:[date mt_stringFromDateWithFormat:@"yyyy" localized:NO]];
   }
   return [partsArray componentsJoinedByString:@" "];

--- a/MTDatesTests/NSDateComponentsTests.m
+++ b/MTDatesTests/NSDateComponentsTests.m
@@ -31,20 +31,20 @@
   comps = [NSDateComponents mt_componentsFromString:@"October 2009"];
   XCTAssertTrue([comps year] == 2009);
   XCTAssertTrue([comps month] == 10);
-  XCTAssertTrue([comps day] == NSUndefinedDateComponent);
+  XCTAssertTrue([comps day] == NSDateComponentUndefined);
 
   comps = [NSDateComponents mt_componentsFromString:@"2009"];
   XCTAssertTrue([comps year] == 2009);
-  XCTAssertTrue([comps month] == NSUndefinedDateComponent);
-  XCTAssertTrue([comps day] == NSUndefinedDateComponent);
+  XCTAssertTrue([comps month] == NSDateComponentUndefined);
+  XCTAssertTrue([comps day] == NSDateComponentUndefined);
 
   comps = [NSDateComponents mt_componentsFromString:@"10 2009"];
   XCTAssertTrue([comps year] == 2009);
   XCTAssertTrue([comps month] == 10);
-  XCTAssertTrue([comps day] == NSUndefinedDateComponent);
+  XCTAssertTrue([comps day] == NSDateComponentUndefined);
 
   comps = [NSDateComponents mt_componentsFromString:@"10 July"];
-  XCTAssertTrue([comps year] == NSUndefinedDateComponent);
+  XCTAssertTrue([comps year] == NSDateComponentUndefined);
   XCTAssertTrue([comps month] == 7);
   XCTAssertTrue([comps day] == 10);
 


### PR DESCRIPTION
NSDateComponentUndefined is actually deprecated in iOS 8 but has been introduced in iOS 7, so these changes are still backward compatible and remove a few warnings on iOS 8.
