### PR TITLE
Replace deprecated calendar identifier

### DIFF
--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -111,7 +111,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
     }
 
     NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-    [formatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+    [formatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
     [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
 
     NSArray *formatsToTry = @[ @"yyyy-MM-dd'T'HH:mm.ss.SSS'Z'", @"yyyy-MM-dd HH:mm:ss ZZZ", @"yyyy-MM-dd HH:mm:ss Z", @"yyyy-MM-dd HH:mm:ss", @"yyyy-MM-dd'T'HH:mm:ss'Z'", @"yyyy-MM-dd" ];
@@ -1392,7 +1392,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 {
 	[[NSDate sharedRecursiveLock] lock];
     NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-    [formatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+    [formatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
     [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ss Z"];
     [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     NSString* result = [formatter stringFromDate:self];

--- a/MTDatesTests/MTDatesTests.m
+++ b/MTDatesTests/MTDatesTests.m
@@ -23,7 +23,7 @@
 {
     NSLocale *locale        = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
     NSTimeZone *timeZone    = [NSTimeZone timeZoneWithName:@"America/Denver"];
-    _calendar               = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    _calendar               = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     
     [NSDate mt_setLocale:locale];
     [NSDate mt_setCalendarIdentifier:_calendar.calendarIdentifier];
@@ -1328,7 +1328,7 @@
     XCTAssertEqual([date2 mt_monthOfYear], 1);
     XCTAssertEqual([date2 mt_dayOfMonth],  1);
 
-    [NSDate mt_setCalendarIdentifier:NSGregorianCalendar];
+    [NSDate mt_setCalendarIdentifier:NSCalendarIdentifierGregorian];
 }
 
 @end


### PR DESCRIPTION
A simple update to replace the deprecated calendar identifier NSGregorianCalendar with NSCalendarIdentifierGregorian.  NSCalendarIdentifierGregorian was 1st introduced in OS/X 10.6 & iOS 4.0.
