### PR TITLE
Fix mt_oneSecondNext issues

### DIFF
--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -1302,7 +1302,7 @@ static NSDateFormatterStyle         __timeStyle             = NSDateFormatterSho
 - (NSDate *)mt_oneSecondNext
 {
 	[[NSDate sharedRecursiveLock] lock];
-    NSDate *date = [self mt_dateByAddingYears:0 months:0 weeks:0 days:0 hours:0 minutes:0 seconds:-1];
+    NSDate *date = [self mt_dateByAddingYears:0 months:0 weeks:0 days:0 hours:0 minutes:0 seconds:1];
 	[[NSDate sharedRecursiveLock] unlock];
     return date;
 }

--- a/MTDatesTests/MTDatesTests.m
+++ b/MTDatesTests/MTDatesTests.m
@@ -896,7 +896,12 @@
     XCTAssertEqual([date2 mt_hoursUntilDate:date], 4);
 }
 
+#pragma mark - SECONDS
 
+- (void)test_oneSecondNext {
+    NSDate *date = [NSDate date];
+    XCTAssertEqual([date.mt_oneSecondNext timeIntervalSinceDate:date], 1);
+}
 
 #pragma mark - COMPARES
 


### PR DESCRIPTION
We were actually mimicking `mt_oneSecondPrevious`. This PR properly increments by one second, instead of the other way around.